### PR TITLE
Create LB/FW/IP temporary files under /tmp directory

### DIFF
--- a/cmd/get/get_firewall.go
+++ b/cmd/get/get_firewall.go
@@ -141,7 +141,7 @@ func FWAPICall(restOptions *api.RESTOptions) (*http.Response, error) {
 
 func FWdump(restOptions *api.RESTOptions, path string) (string, error) {
 	// File Open
-	fileP := []string{"FWconfig_", ".txt"}
+	fileP := []string{"/tmp/FWconfig_", ".txt"}
 	t := time.Now()
 	file := strings.Join(fileP, t.Local().Format("2006-01-02_15:04:05"))
 	f, err := os.Create(file)
@@ -149,7 +149,7 @@ func FWdump(restOptions *api.RESTOptions, path string) (string, error) {
 		fmt.Printf("Can't create dump file\n")
 		os.Exit(1)
 	}
-	defer f.Close()
+	defer os.Remove(f.Name())
 
 	// API Call
 	client := api.NewLoxiClient(restOptions)

--- a/cmd/get/get_loadbalancer.go
+++ b/cmd/get/get_loadbalancer.go
@@ -225,7 +225,7 @@ func Lbdump(restOptions *api.RESTOptions, path string) (string, error) {
 	lbresp := api.LbRuleModGet{}
 	dresp := api.LbRuleModGet{}
 	// File Open
-	fileP := []string{"lbconfig_", ".txt"}
+	fileP := []string{"/tmp/lbconfig_", ".txt"}
 	t := time.Now()
 	file := strings.Join(fileP, t.Local().Format("2006-01-02_15:04:05"))
 	f, err := os.Create(file)
@@ -233,7 +233,7 @@ func Lbdump(restOptions *api.RESTOptions, path string) (string, error) {
 		fmt.Printf("Can't create dump file\n")
 		os.Exit(1)
 	}
-	defer f.Close()
+	defer os.Remove(f.Name())
 
 	// API Call
 	client := api.NewLoxiClient(restOptions)

--- a/cmd/get/get_netlink.go
+++ b/cmd/get/get_netlink.go
@@ -514,7 +514,7 @@ func GetBonds() {
 func Nlpdump(dpath string) (string, error) {
 	var ret int
 	var err error
-	fileP := []string{"ipconfig_", ".txt"}
+	fileP := []string{"/tmp/ipconfig_", ".txt"}
 	t := time.Now()
 	file := strings.Join(fileP, t.Local().Format("2006-01-02_15:04:05"))
 	f, err = os.Create(file)
@@ -523,9 +523,9 @@ func Nlpdump(dpath string) (string, error) {
 		os.Exit(1)
 	}
 
-	defer f.Close()
+	defer os.Remove(f.Name())
 
-	path = "ipconfig_" + t.Local().Format("2006-01-02_15:04:05") + "/"
+	path = "/tmp/" + "ipconfig_" + t.Local().Format("2006-01-02_15:04:05") + "/"
 	//fmt.Printf("Creating intf config dir : %s\n", path)
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		err := os.Mkdir(path, os.ModePerm)
@@ -533,6 +533,8 @@ func Nlpdump(dpath string) (string, error) {
 			fmt.Println("Can't create config dir")
 		}
 	}
+
+	defer os.RemoveAll(path)
 
 	/*Get bridge info first */
 	GetBridges()


### PR DESCRIPTION
When run loxicmd save -c "dir" with --ip or --firewall or --lb from BPFire web interface with user "nobody" when "dir" is owned by user "nobody", web inrerface got error "Can't create dump file".

The issue is reported in https://github.com/vincentmli/BPFire/issues/30 with the help of libbpf-tools opensnoop, the permission error shows below:

PID    COMM              FD ERR PATH

23194  loxicmd           -1  13 lbconfig_2024-08-23_19:00:35.txt

ERR 13 is EACCESS, and the PATH is lbconfig_2024-08-23_19:00:35.txt

"lbconfig_2024-08-23_19:00:35.txt" is neither under "dir" nor "/tmp" which web user "nobody" has permission to create file in.

since "lbconfig_2024-08-23_19:00:35.txt" is temporary file, we can create the temporary file under /tmp directory and automatically get removed after loxicmd exit.

fix: https://github.com/loxilb-io/loxicmd/issues/26